### PR TITLE
correct action naming from markdown to md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The markdown formatted table
 ## Example usage
 
 ```yaml
-uses: petems/csv-to-markdown-action@master
+uses: petems/csv-to-md-action@master
 with:
   csvinput: | 
     First Name, Last Name, Address, Town, State, Zip
@@ -45,7 +45,7 @@ jobs:
         uses: juliangruber/read-file-action@v1
         with:
           path: ./people.csv
-      uses: petems/csv-to-markdown-action@master
+      uses: petems/csv-to-md-action@master
         id: csv-table-output
         with:
           csvinput: ${{ steps.csv.outputs.content }}


### PR DESCRIPTION
I ran across this issue while trying to copy and paste from the `README.md` example workflow syntax. Seems the name has changed or been written incorrectly.